### PR TITLE
hotfix when there is only one qrcode

### DIFF
--- a/src/components/list-items/BaseListItemReward.vue
+++ b/src/components/list-items/BaseListItemReward.vue
@@ -51,7 +51,7 @@
                     <b-dropdown-item-button v-if="reward.amount > 1" @click="getQRCodes()">
                         <i class="fas fa-qrcode mr-3"></i>Download {{ reward.amount }} QR codes
                     </b-dropdown-item-button>
-                    <b-dropdown-item v-if="reward.amount === 1" :download="`${reward._id}.jpg`" :href="qrURL">
+                    <b-dropdown-item v-if="reward.amount === 1" @click="getQRCodes()">
                         <i class="fas fa-qrcode mr-3"></i>Download QR code
                     </b-dropdown-item>
                     <b-dropdown-item @click="toggleState()">


### PR DESCRIPTION
handled the case when there is only one qrcode. 
It can be handled better downloading directly the qrcode image instead of the zip file
@peterpolman 